### PR TITLE
CFE-3745: Fixed configuration to target /var/cfengine

### DIFF
--- a/recipes-cfengine/cfengine-masterfiles_3.21.0.bb
+++ b/recipes-cfengine/cfengine-masterfiles_3.21.0.bb
@@ -25,16 +25,18 @@ SRC_URI = "https://cfengine-package-repos.s3.amazonaws.com/tarballs/${BP}.tar.gz
 #SRC_URI[md5sum] = "5df2f85c75efc351ffadebcc11046a98"
 SRC_URI[sha256sum] = "013ebe68599915cedb4bf753b471713d91901a991623358b9a967d9a779bcc16"
 
-inherit autotools
+inherit autotools-brokensep
 
 export EXPLICIT_VERSION="${PV}"
 
-EXTRA_OECONF = "--prefix=${datadir}/cfengine"
+# The default of /var/cfengine is preferred and best supported
+CFE_WORKDIR = "/var/cfengine"
+EXTRA_OECONF += "--prefix=${CFE_WORKDIR}"
 
 do_install:append() {
     rm -rf ${D}${datadir}/cfengine/modules/packages/zypper ${D}${datadir}/cfengine/modules/packages/yum
 }
 
-FILES:${PN} = "${datadir}/cfengine"
+FILES:${PN} = "${CFE_WORKDIR}"
 
 RDEPENDS:${PN} += "python3-core"

--- a/recipes-cfengine/cfengine_3.21.0.bb
+++ b/recipes-cfengine/cfengine_3.21.0.bb
@@ -50,6 +50,11 @@ PACKAGECONFIG[libcurl] = "--with-libcurl,--without-libcurl,curl,"
 
 EXTRA_OECONF = "hw_cv_func_va_copy=yes --with-init-script=${sysconfdir}/init.d --with-tokyocabinet"
 
+# The default of /var/cfengine is preferred and best supported
+CFE_WORKDIR = "/var/cfengine"
+EXTRA_OECONF += "--prefix=${CFE_WORKDIR} --with-workdir=${CFE_WORKDIR}"
+
+# distribution tarballs come pre-autoconf'd to an older libtool version, so need to reconfigure
 do_configure:prepend() {
     autoreconf -i
 }
@@ -73,6 +78,7 @@ EOF
         sed -i -e 's#/etc/init.d#${datadir}/${BPN}#' ${D}${systemd_system_unitdir}/*.service
     fi
     rm -rf ${D}${datadir}/cfengine/modules/packages/zypper
+    find ${D} -name remake_outputs.pl | xargs rm
 }
 
 RDEPENDS:${PN} += "${BPN}-masterfiles"


### PR DESCRIPTION
Previously the result of autotools configuration was a mix of `/var/cfengine` and `/var/libntech` which caused problems with bootstrapping and other functionality.

Ticket: CFE-3745
Changelog: title
